### PR TITLE
고침: language가 형식과 다를 경우

### DIFF
--- a/dynamic_contents/models.py
+++ b/dynamic_contents/models.py
@@ -34,7 +34,7 @@ class BaseModel(models.Model):
         # content 필드에 대한 현재 언어 버전의 속성명을 생성합니다.
         content_field_name = f"content_{current_language.replace('-', '_')}"
         # 현재 언어 버전의 content 값을 반환하되, 없다면 기본 content 값을 사용합니다.
-        if content := getattr(self, content_field_name):
+        if content := getattr(self, content_field_name, None):
             return content
         else:
             return self.content


### PR DESCRIPTION
# Summary
- vpn을 통해서 get_language를 할 경우 en-us 가 반환되는데, 이에 대응되는 필드가 없어서 에러 발생